### PR TITLE
Added feature to jsonify standard HTTP errors

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -251,6 +251,17 @@ headers::
                         headers_=dict(MYHEADER=12, HEADER2='fail'),
                         error_description='Server is down')
 
+Jsonify HTTP errors
+-------------------
+
+:ref:`JSON_JSONIFY_HTTP_ERRORS <opt_jsonify_http_errors>` option allows to
+force returning all standard HTTP errors as JSON.
+
+Now response looks this way::
+
+    $ curl http://localhost:5000
+    {"description":"The server encountered an internal error and was unable to complete your request.  Either the server is overloaded or there is an error in the application.", "reason":"Internal Server Error", "status":500}
+
 Encoding values
 ===============
 
@@ -556,6 +567,17 @@ You can configure Flask-JSON with the following options:
                                 List of allowed JSONP callback query parameters.
 
                                 Default: ``['callback', 'jsonp']``.
+
+``JSON_JSONIFY_HTTP_ERRORS``    .. _opt_jsonify_http_errors:
+
+                                Return standard HTTP Errors as JSON instead of
+                                HTML by default.
+
+                                Note: this will register custom error handler
+                                in Flask. So, this option should be set before
+                                the init of FlaskJSON.
+
+                                Default: ``False``.
 ==============================  ================================================
 
 See :ref:`python:strftime-strptime-behavior` for more info about time related

--- a/flask_json.py
+++ b/flask_json.py
@@ -559,7 +559,7 @@ class FlaskJSON(object):
             if app.config['JSON_ADD_STATUS']:
                 response[status_field] = status_code
 
-            if error.description:
+            if isinstance(error, HTTPException) and error.description:
                 response['description'] = error.description
 
             return json_response(status_code, data_=response)

--- a/flask_json.py
+++ b/flask_json.py
@@ -559,18 +559,22 @@ class FlaskJSON(object):
             if app.config['JSON_ADD_STATUS']:
                 response[status_field] = status_code
 
-            if isinstance(error, HTTPException) and error.description:
+            if error.description:
                 response['description'] = error.description
 
             return json_response(status_code, data_=response)
 
         for code, exc in default_exceptions.items():
-            app.register_error_handler(code, partial(
-                _handler,
-                status_code=code,
-                reason=exc().name,
-                default_description=exc.description,
-            ))
+            try:
+                if issubclass(exc, HTTPException):
+                    app.register_error_handler(code, partial(
+                        _handler,
+                        status_code=code,
+                        reason=exc().name,
+                        default_description=exc.description,
+                    ))
+            except TypeError:
+                continue
 
     def error_handler(self, func):
         """This decorator allows to set custom handler for the

--- a/tests/test_jsonify_http_errors.py
+++ b/tests/test_jsonify_http_errors.py
@@ -1,0 +1,61 @@
+"""
+This module provides tests for JSON_JSONIFY_HTTP_ERRORS feature.
+"""
+from flask import abort
+from flask_json import FlaskJSON
+import pytest
+from werkzeug.exceptions import InternalServerError, NotFound
+
+
+@pytest.fixture
+def theapp(app):
+    # Enable feature
+    app.config['JSON_JSONIFY_HTTP_ERRORS'] = True
+    # set raise to result in 500 error
+    app.config["PROPAGATE_EXCEPTIONS"] = False
+    FlaskJSON(app)
+    return app
+
+
+class TestJsonifyHttpError(object):
+    # Test: raise HTTP error by flask.abort
+    def test_abort(self, theapp, client):
+        @theapp.route('/test')
+        def endpoint():
+            abort(404)
+
+        r = client.get('/test')
+        assert r.status_code == 404
+        assert r.json == {
+            'status': 404,
+            'description': NotFound.description,
+            'reason': 'Not Found',
+        }
+
+    # Test: raise HTTP error by flask.abort with custom message
+    def test_abort_with_custom_message(self, theapp, client):
+        @theapp.route('/test')
+        def endpoint():
+            abort(400, 'Custom message')
+
+        r = client.get('/test')
+        assert r.status_code == 400
+        assert r.json == {
+            'status': 400,
+            'description': 'Custom message',
+            'reason': 'Bad Request',
+        }
+
+    # Test: raise regular Exception
+    def test_raise_exception(self, theapp, client):
+        @theapp.route('/test')
+        def endpoint():
+            raise ValueError()
+
+        r = client.get('/test')
+        assert r.status_code == 500
+        assert r.json == {
+            'status': 500,
+            'description': InternalServerError.description,
+            'reason': 'Internal Server Error',
+        }


### PR DESCRIPTION
Added new feature to return standard HTTP Errors as JSON instead of HTML by default.
Can be turned on using `JSON_JSONIFY_HTTP_ERRORS` config option.

I use this feature a lot in my projects to make the API consistent (always JSON).

Please, review it.
If you consider it as a suitable feature for your project, I will proceed with documentation and tests.