### PR TITLE
Remove extra quoting in bumpversion commit msg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -2,7 +2,7 @@
 current_version = 0.3.2
 commit = True
 tag = False
-message = "Bump version to {new_version}"
+message = Bump version to {new_version}
 
 [bumpversion:file:flask_json.py]
 search = __version__ = '{current_version}'


### PR DESCRIPTION
This fix will make more clean commit messages. i.e.
```
Bump version to 0.3.2
```
instead of current:
```
"Bump version to 0.3.2"
```